### PR TITLE
Update aio_launcher.py

### DIFF
--- a/aio_launcher.py
+++ b/aio_launcher.py
@@ -102,8 +102,8 @@ if __name__ == "__main__":
                 print(f"[INSTANCE-{shard.id}]: {shard.execute(i)}")
             
             if i == "exit":
-                sys.exit(1)
+                sys.exit(0)
     except KeyboardInterrupt:
         for shard in shards:
             shard.client.loop.stop()
-        sys.exit(1)
+        sys.exit(0)


### PR DESCRIPTION
If an issue arises, such as an exception that can't be recovered from, a non-zero exit should be used. In this case, a KeyboardInterrupt is a normal exit and should return as such.

In addition, if user inputs "exit", this should be treated as a "normal" exit.