### PR TITLE
KeyboardInterrupt should be a 0 exit

### DIFF
--- a/aio_launcher.py
+++ b/aio_launcher.py
@@ -106,4 +106,4 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         for shard in shards:
             shard.client.loop.stop()
-        sys.exit(1)
+        sys.exit(0)


### PR DESCRIPTION
If an issue arises, such as an exception that can't be recovered from, a non-zero exit should be used. In this case, a KeyboardInterrupt is a normal exit and should return as such.